### PR TITLE
The source docker image does not exist anymore. I tested change, see …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pudo/aleph:latest
+FROM code4sa/aleph:latest
 
 ENV ELASTICSEARCH_INDEX aleph
 ENV ALEPH_SETTINGS /aleph/contrib/docker_settings.py


### PR DESCRIPTION
…extended description for details.

Sending build context to Docker daemon  2.048kB
Step 1/6 : FROM code4sa/aleph:latest
 ---> 98caaa457180
Step 2/6 : ENV ELASTICSEARCH_INDEX aleph
 ---> Using cache
 ---> 7cc07230d228
Step 3/6 : ENV ALEPH_SETTINGS /aleph/contrib/docker_settings.py
 ---> Running in 3df777853ba4
Removing intermediate container 3df777853ba4
 ---> 74daf771a1a4
Step 4/6 : RUN mkdir /app
 ---> Running in dced7aafecad
Removing intermediate container dced7aafecad
 ---> c1018ab7ffea
Step 5/6 : WORKDIR /aleph
 ---> Running in 5dd3c21ed9e3
Removing intermediate container 5dd3c21ed9e3
 ---> c30e5b65bc26
Step 6/6 : CMD celery -A aleph.queue beat -s /var/run/celerybeat-schedule
 ---> Running in 6d867fca480a
Removing intermediate container 6d867fca480a
 ---> c12f0f0b24aa
Successfully built c12f0f0b24aa